### PR TITLE
Fixing paths to misc and charles js files

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,9 +327,9 @@
 
 <script type="text/javascript" src="https://www.dosomething.org/sites/default/files/assets/v0.5.1/dist/lib.js?npqjx8"></script>
 <script type="text/javascript" src="https://www.dosomething.org/misc/drupal.js?npqjx8"></script>
-<script type="text/javascript" src="misc.js"></script>
+<script type="text/javascript" src="https://www.dosomething.org/sites/default/files/assets/v0.5.1/js/misc.js"></script>
 <script type="text/javascript" src="https://www.dosomething.org/sites/default/files/assets/v0.5.1/dist/app.js?npqjx8"></script>
-<script type="text/javascript" src="charleston.js"></script>
+<script type="text/javascript" src="https://www.dosomething.org/sites/default/files/assets/v0.5.1/js/charleston.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
The js files misc.js and charleston.js live on ds.org origin, just adding the full paths to the files.

@DFurnes 
