### PR TITLE
Fix wonkiness in Firefox.

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
 
       .charleston-responses li {
           display: none;
+          font-size: 22px;
       }
 
       @media (min-width: 760px) {
@@ -138,7 +139,7 @@
     <main class="charleston-container">
       <div class="header header--charleston" role="banner">
         <div class="wrapper">
-            <div id="responses" class="charleston-responses" style="display: none;">
+            <div id="responses" class="charleston-responses">
                 <ul class="wrapper">
                     <li>
                         This country is over flowing with disgusting racism. Someone needs to do something about this injustice.

--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
           color: #fff;
           text-align: center;
           min-height: 275px;
+          height: 40vh;
           max-width: 700px;
           margin: 12px auto 0;
       }
@@ -109,6 +110,7 @@
       @media (min-width: 760px) {
           .charleston-responses {
               margin: 24px auto 24px;
+              height: 50vh;
           }
 
           .charleston-responses li {
@@ -472,7 +474,6 @@
                         Racism needs to end. Unity is the answer, hate is not. We can't change together until we change individually. Deepest sympathies go out to the families involved
                         <cite class="footnote">&mdash; Nick, 22</cite>
                     </li>
-
 
                 </ul>
             </div>


### PR DESCRIPTION
# Changes

Fixes wonky behavior in Firefox when switching quotes. This was happening because Firefox doesn't support `display: table-*` on elements with a `min-height` set. Setting the container based on `vh` fixes that.
